### PR TITLE
Treat decommissioning (Prefer)NoSchedule taints as active but phased out capacity

### DIFF
--- a/node/constants.go
+++ b/node/constants.go
@@ -10,6 +10,7 @@ const (
 	// Possible node states
 	NodeStateBootstrapping  = "bootstrapping"
 	NodeStateActive         = "active"
+	NodeStatePhasedOut      = "phasedOut"
 	NodeStateDecommissioned = "decommissioned"
 	NodeStateScalingDown    = "scalingDown"
 	NodeStateBroken         = "broken"
@@ -19,6 +20,7 @@ const (
 var NodeStatesAll = []string{
 	NodeStateBootstrapping,
 	NodeStateActive,
+	NodeStatePhasedOut,
 	NodeStateDecommissioned,
 	NodeStateScalingDown,
 	NodeStateBroken,


### PR DESCRIPTION
* A decommissioning node is considered NodeStateDecommissioned only if it has a NoExecute taint

* Introduced new NodeStatePhaseOut to classify decommissioning nodes with NoSchedule/PreferNoSchedule effect