### PR TITLE
Return debug map that contains available capacity per node for visibility

### DIFF
--- a/resourcepool/allocation.go
+++ b/resourcepool/allocation.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ComputeAllocatableCapacityFromSnapshot(snapshot *ResourceSnapshot,
-	minimumResources scaler.ComputeResource, adjust bool) scaler.ComputeResource {
+	minimumResources scaler.ComputeResource, adjust bool) (scaler.ComputeResource, map[string]scaler.ComputeResource) {
 	scheduledPods := snapshot.PodSnapshot.ScheduledByName
 	return ComputeAllocatableCapacity(scheduledPods, snapshot.NodeSnapshot.ActiveByName, minimumResources, adjust)
 }
@@ -18,8 +18,10 @@ func ComputeAllocatableCapacityFromSnapshot(snapshot *ResourceSnapshot,
 // In order to compute allocatable capacity and be robust to the opportunistic-cpu-driven oversubscription case,
 // we cannot work in aggregate and subtract total allocated capacity from total provisioned capacity.
 // We need to do the accounting per node, and then sum.
+// The second return value is a map that contains actual remaining capacity per node without taking any
+// DRF resource adjustment and minimum resource size check for debugging purposes.
 func ComputeAllocatableCapacity(scheduledPods map[string]*v1.Pod, nodes map[string]*v1.Node,
-	minimumResources scaler.ComputeResource, adjust bool) scaler.ComputeResource {
+	minimumResources scaler.ComputeResource, adjust bool) (scaler.ComputeResource, map[string]scaler.ComputeResource) {
 	nodeToAvailable := make(map[string]scaler.ComputeResource)
 	nodeToUsed := make(map[string]scaler.ComputeResource)
 
@@ -40,6 +42,7 @@ func ComputeAllocatableCapacity(scheduledPods map[string]*v1.Pod, nodes map[stri
 	// Sum what is remaining, but only look at nodes with large enough resource chunks left.
 	// Align the remaining resources to the mostly utilized resource.
 	tot := scaler.ComputeResource{}
+	nodeRemainingCapacityDebug := map[string]scaler.ComputeResource{}
 	for nodeID, nodeUsed := range nodeToUsed {
 		nodeAvailable := nodeToAvailable[nodeID]
 		nodeRemaining := nodeAvailable.SubWithLimit(nodeUsed, 0)
@@ -51,7 +54,8 @@ func ComputeAllocatableCapacity(scheduledPods map[string]*v1.Pod, nodes map[stri
 			remainingAdjusted := nodeAvailable.SubWithLimit(adjustedUsed, 0)
 			tot = tot.Add(remainingAdjusted)
 		}
+		nodeRemainingCapacityDebug[nodeID] = nodeRemaining
 	}
 
-	return tot
+	return tot, nodeRemainingCapacityDebug
 }

--- a/resourcepool/allocation_test.go
+++ b/resourcepool/allocation_test.go
@@ -24,12 +24,15 @@ func TestComputeAllocatableCapacity(t *testing.T) {
 
 	// We expect 25% across all dimensions
 	nodes := map[string]*k8sCore.Node{node.Name: node}
-
+	available := nodeAvailable.Sub(podResources)
+	nodesActualRemaining := map[string]scaler.ComputeResource{node.Name: available}
 	// Adjusted
-	remaining := ComputeAllocatableCapacity(map[string]*k8sCore.Pod{pod.Name: pod}, nodes, scaler.Zero, true)
+	remaining, nodeRemainingCapDebug := ComputeAllocatableCapacity(map[string]*k8sCore.Pod{pod.Name: pod}, nodes, scaler.Zero, true)
 	require.Equal(t, nodeAvailable.Divide(4), remaining)
+	require.Equal(t, nodesActualRemaining, nodeRemainingCapDebug)
 
 	// Not adjusted
-	remaining = ComputeAllocatableCapacity(map[string]*k8sCore.Pod{pod.Name: pod}, nodes, scaler.Zero, false)
-	require.Equal(t, nodeAvailable.Sub(podResources), remaining)
+	remaining, nodeRemainingCapDebug = ComputeAllocatableCapacity(map[string]*k8sCore.Pod{pod.Name: pod}, nodes, scaler.Zero, false)
+	require.Equal(t, available, remaining)
+	require.Equal(t, nodesActualRemaining, nodeRemainingCapDebug)
 }


### PR DESCRIPTION
When calculating aggregate allocatable capacity we round up per resource utilization to the dominant resource utilization and consider is allocatable only when it is greater than a given minimum resource shape. While this behavior is configuration by the consumer of this logic, it is unclear how much capacity is removed from the nodes. 
For debugging purposes, we additionally return a debug map of node to actual available capacity to the caller. 