### PR TITLE
Handle nodes with Evacuate/NoExecute taints

### DIFF
--- a/node/queries.go
+++ b/node/queries.go
@@ -141,8 +141,13 @@ func IsNodeScalingDown(node *k8sCore.Node) bool {
 	return FindTaint(node, commonNode.TaintKeyNodeScalingDown) != nil
 }
 
+func IsNodeEvacuating(node *k8sCore.Node) bool {
+	taint := FindTaint(node, commonNode.TaintKeyNodeEvacuate)
+	return taint != nil && taint.Effect == k8sCore.TaintEffectNoExecute
+}
+
 func IsNodeToRemove(node *k8sCore.Node) bool {
-	return IsNodeDecommissioned(node) || IsNodeScalingDown(node)
+	return IsNodeDecommissioned(node) || IsNodeScalingDown(node) || IsNodeEvacuating(node)
 }
 
 func IsNodeRemovable(node *k8sCore.Node) bool {


### PR DESCRIPTION
Nodes with Evacuate/NoExecute taints need be handled as non-schedulable and removable for capacity management purposes. This will relieve us from managing a combination of 3 different types of NoExec taints: Decommissioning, ScalingDown and Evacuate in order to drive scaling and node removal behavior in a simpler way such that:
1. Decommissioned is used by tad/decoy
2. ScalingDown is used by capacity controller scale down + defragger
3. Evacuate is used by node problem detector and remediation controller